### PR TITLE
fix the path of test-vectors 

### DIFF
--- a/src/token/evidence.rs
+++ b/src/token/evidence.rs
@@ -510,13 +510,13 @@ mod tests {
 
     #[test]
     fn test_file_path_creation() {
-       let basedir: Path = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let basedir: Path = Path::new(env!("CARGO_MANIFEST_DIR"));
 
-       let cca_token_path: Path = basedir.join("testdata/cca-token.cbor");
-       let cca_rv_path: Path = basedir.join("testdata/rv.json");
-       let cbor_claims_path: Path = basedir.join("testdata/verification/cca_claims.cbor");
-       let pkey_1_path: Path = basedir.join("testdata/verification/pkey-verify-success.json");
-       let pkey_2_path: Path = basedir.join("testdata/verification/pkey-verify-fail.json");
+        let cca_token_path: Path = basedir.join("testdata/cca-token.cbor");
+        let cca_rv_path: Path = basedir.join("testdata/rv.json");
+        let cbor_claims_path: Path = basedir.join("testdata/verification/cca_claims.cbor");
+        let pkey_1_path: Path = basedir.join("testdata/verification/pkey-verify-success.json");
+        let pkey_2_path: Path = basedir.join("testdata/verification/pkey-verify-fail.json");
     }
     #[test]
     fn decode_good_token() {

--- a/src/token/evidence.rs
+++ b/src/token/evidence.rs
@@ -508,11 +508,17 @@ mod tests {
     use super::*;
     use crate::store::MemoRefValueStore;
 
-    const TEST_CCA_TOKEN_OK: &[u8; 1222] = include_bytes!("../../testdata/cca-token.cbor");
-    const TEST_CCA_RVS_OK: &str = include_str!("../../testdata/rv.json");
-    const TEST_CBOR_CLAIMS: &str = "testdata/verification/cca-claims.cbor";
-    const TEST_PKEY_1: &str = include_str!("../../testdata/verification/pkey-verify-success.json");
-    const TEST_PKEY_2: &str = include_str!("../../testdata/verification/pkey-verify-fail.json");
+    const cca_token_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/cca-token.cbor");
+    const cca_rv_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/rv.json");
+    const cbor_claims_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/verification/cca_claims.cbor");
+    const pkey_1_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/verification/pkey-verify-success.json");
+    const pkey_2_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/verification/pkey-verify-fail.json");
+
+    const TEST_CCA_TOKEN_OK: &[u8; 1222] = include_bytes!(&cca_token_path);
+    const TEST_CCA_RVS_OK: &str = include_str!(&cca_rv_path);
+    const TEST_CBOR_CLAIMS: &str = cbor_claims_path;
+    const TEST_PKEY_1: &str = include_str!(&pkey_1_path);
+    const TEST_PKEY_2: &str = include_str!(&pkey_2_path);
     #[test]
     fn decode_good_token() {
         let r = Evidence::decode(&TEST_CCA_TOKEN_OK.to_vec());

--- a/src/token/evidence.rs
+++ b/src/token/evidence.rs
@@ -508,17 +508,14 @@ mod tests {
     use super::*;
     use crate::store::MemoRefValueStore;
 
-    const cca_token_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/cca-token.cbor");
-    const cca_rv_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/rv.json");
-    const cbor_claims_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/verification/cca_claims.cbor");
-    const pkey_1_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/verification/pkey-verify-success.json");
-    const pkey_2_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/verification/pkey-verify-fail.json");
+    let basedir: Path = Path::new(env!("CARGO_MANIFEST_DIR"));
 
-    const TEST_CCA_TOKEN_OK: &[u8; 1222] = include_bytes!(&cca_token_path);
-    const TEST_CCA_RVS_OK: &str = include_str!(&cca_rv_path);
-    const TEST_CBOR_CLAIMS: &str = cbor_claims_path;
-    const TEST_PKEY_1: &str = include_str!(&pkey_1_path);
-    const TEST_PKEY_2: &str = include_str!(&pkey_2_path);
+    let cca_token_path: Path = basedir.join("testdata/cca-token.cbor");
+    let cca_rv_path: Path = basedir.join("testdata/rv.json");
+    let cbor_claims_path: Path = basedir.join("testdata/verification/cca_claims.cbor");
+    let pkey_1_path: Path = basedir.join("testdata/verification/pkey-verify-success.json");
+    let pkey_2_path: Path = basedir.join("testdata/verification/pkey-verify-fail.json");
+
     #[test]
     fn decode_good_token() {
         let r = Evidence::decode(&TEST_CCA_TOKEN_OK.to_vec());

--- a/src/token/evidence.rs
+++ b/src/token/evidence.rs
@@ -508,14 +508,16 @@ mod tests {
     use super::*;
     use crate::store::MemoRefValueStore;
 
-    let basedir: Path = Path::new(env!("CARGO_MANIFEST_DIR"));
+    #[test]
+    fn test_file_path_creation() {
+       let basedir: Path = Path::new(env!("CARGO_MANIFEST_DIR"));
 
-    let cca_token_path: Path = basedir.join("testdata/cca-token.cbor");
-    let cca_rv_path: Path = basedir.join("testdata/rv.json");
-    let cbor_claims_path: Path = basedir.join("testdata/verification/cca_claims.cbor");
-    let pkey_1_path: Path = basedir.join("testdata/verification/pkey-verify-success.json");
-    let pkey_2_path: Path = basedir.join("testdata/verification/pkey-verify-fail.json");
-
+       let cca_token_path: Path = basedir.join("testdata/cca-token.cbor");
+       let cca_rv_path: Path = basedir.join("testdata/rv.json");
+       let cbor_claims_path: Path = basedir.join("testdata/verification/cca_claims.cbor");
+       let pkey_1_path: Path = basedir.join("testdata/verification/pkey-verify-success.json");
+       let pkey_2_path: Path = basedir.join("testdata/verification/pkey-verify-fail.json");
+    }
     #[test]
     fn decode_good_token() {
         let r = Evidence::decode(&TEST_CCA_TOKEN_OK.to_vec());

--- a/src/token/platform.rs
+++ b/src/token/platform.rs
@@ -496,8 +496,8 @@ mod tests {
     #[test]
     fn platform_ok() {
         
-        const test_vector_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/platform-claims.cbor");
-        let buf = include_bytes!(&let_vector_path).to_vec();
+        let basedir: Path = Path::new(env!("CARGO_MANIFEST_DIR")); 
+        let test_vector_path: Path = basedir.join("testdata/platform-claims.cbor");
 
         let _p = Platform::decode(&buf).unwrap();
 

--- a/src/token/platform.rs
+++ b/src/token/platform.rs
@@ -495,7 +495,9 @@ mod tests {
 
     #[test]
     fn platform_ok() {
-        let buf = include_bytes!("../../testdata/platform-claims.cbor").to_vec();
+        
+        const test_vector_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/platform-claims.cbor");
+        let buf = include_bytes!(&let_vector_path).to_vec();
 
         let _p = Platform::decode(&buf).unwrap();
 

--- a/src/token/realm.rs
+++ b/src/token/realm.rs
@@ -299,14 +299,16 @@ impl Realm {
 mod tests {
     use super::*;
     use hex_literal::hex;
+    
+    #[test]
+    fn test_file_path_creation(){
+      let basedir: Path = Path::new(env!("CARGO_MANIFEST_DIR"));
 
-    let basedir: Path = Path::new(env!("CARGO_MANIFEST_DIR"));
-
-    let realm_claims_path: Path = basedir.join("testdata/realm-claims.cbor");
-    let num_key_path: Path =  basedir.join("testdata/realm-claims+spurious-numeric-key.cbor");
-    let text_key_path: Path = basedir.join("testdata/realm-claims+spurious-text-key.cbor");
-    let missing_claims_path: Path = basedir.join("testdata/realm-claims-missing-challange.cbor");
-
+      let realm_claims_path: Path = basedir.join("testdata/realm-claims.cbor");
+      let num_key_path: Path =  basedir.join("testdata/realm-claims+spurious-numeric-key.cbor");
+      let text_key_path: Path = basedir.join("testdata/realm-claims+spurious-text-key.cbor");
+      let missing_claims_path: Path = basedir.join("testdata/realm-claims-missing-challange.cbor");
+    }
     #[test]
     fn realm_ok() {
         let _r = Realm::decode(&TEST_REALM_CLAIMS_OK.to_vec()).expect("successful decode");

--- a/src/token/realm.rs
+++ b/src/token/realm.rs
@@ -300,15 +300,12 @@ mod tests {
     use super::*;
     use hex_literal::hex;
 
-    const realm_claims_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/realm-claims.cbor");
-    const num_key_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/realm-claims+spurious-numeric-key.cbor");
-    const text_key_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/realm-claims+spurious-text-key.cbor");
-    const missing_claims_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/realm-claims-missing-challange.cbor");
-        
-    const TEST_REALM_CLAIMS_OK: &[u8; 438] = include_bytes!(&realm_claims_path);
-    const TEST_REALM_CLAIMS_BAD_EXTRA_NUMERIC_KEY: &[u8; 457] = include_bytes!(&num_key_path);
-    const TEST_REALM_CLAIMS_BAD_EXTRA_TEXT_KEY: &[u8; 464] = include_bytes!(&text_key_path);
-    const TEST_REALM_CLAIMS_BAD_MISSING_NONCE: &[u8; 371] = include_bytes!(&missing_claims_path);
+    let basedir: Path = Path::new(env!("CARGO_MANIFEST_DIR"));
+
+    let realm_claims_path: Path = basedir.join("testdata/realm-claims.cbor");
+    let num_key_path: Path =  basedir.join("testdata/realm-claims+spurious-numeric-key.cbor");
+    let text_key_path: Path = basedir.join("testdata/realm-claims+spurious-text-key.cbor");
+    let missing_claims_path: Path = basedir.join("testdata/realm-claims-missing-challange.cbor");
 
     #[test]
     fn realm_ok() {

--- a/src/token/realm.rs
+++ b/src/token/realm.rs
@@ -302,12 +302,12 @@ mod tests {
     
     #[test]
     fn test_file_path_creation(){
-      let basedir: Path = Path::new(env!("CARGO_MANIFEST_DIR"));
+       let basedir: Path = Path::new(env!("CARGO_MANIFEST_DIR"));
 
-      let realm_claims_path: Path = basedir.join("testdata/realm-claims.cbor");
-      let num_key_path: Path =  basedir.join("testdata/realm-claims+spurious-numeric-key.cbor");
-      let text_key_path: Path = basedir.join("testdata/realm-claims+spurious-text-key.cbor");
-      let missing_claims_path: Path = basedir.join("testdata/realm-claims-missing-challange.cbor");
+       let realm_claims_path: Path = basedir.join("testdata/realm-claims.cbor");
+       let num_key_path: Path =  basedir.join("testdata/realm-claims+spurious-numeric-key.cbor");
+       let text_key_path: Path = basedir.join("testdata/realm-claims+spurious-text-key.cbor");
+       let missing_claims_path: Path = basedir.join("testdata/realm-claims-missing-challange.cbor");
     }
     #[test]
     fn realm_ok() {

--- a/src/token/realm.rs
+++ b/src/token/realm.rs
@@ -300,13 +300,15 @@ mod tests {
     use super::*;
     use hex_literal::hex;
 
-    const TEST_REALM_CLAIMS_OK: &[u8; 438] = include_bytes!("../../testdata/realm-claims.cbor");
-    const TEST_REALM_CLAIMS_BAD_EXTRA_NUMERIC_KEY: &[u8; 457] =
-        include_bytes!("../../testdata/realm-claims+spurious-numeric-key.cbor");
-    const TEST_REALM_CLAIMS_BAD_EXTRA_TEXT_KEY: &[u8; 464] =
-        include_bytes!("../../testdata/realm-claims+spurious-text-key.cbor");
-    const TEST_REALM_CLAIMS_BAD_MISSING_NONCE: &[u8; 371] =
-        include_bytes!("../../testdata/realm-claims-missing-challenge.cbor");
+    const realm_claims_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/realm-claims.cbor");
+    const num_key_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/realm-claims+spurious-numeric-key.cbor");
+    const text_key_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/realm-claims+spurious-text-key.cbor");
+    const missing_claims_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/realm-claims-missing-challange.cbor");
+        
+    const TEST_REALM_CLAIMS_OK: &[u8; 438] = include_bytes!(&realm_claims_path);
+    const TEST_REALM_CLAIMS_BAD_EXTRA_NUMERIC_KEY: &[u8; 457] = include_bytes!(&num_key_path);
+    const TEST_REALM_CLAIMS_BAD_EXTRA_TEXT_KEY: &[u8; 464] = include_bytes!(&text_key_path);
+    const TEST_REALM_CLAIMS_BAD_MISSING_NONCE: &[u8; 371] = include_bytes!(&missing_claims_path);
 
     #[test]
     fn realm_ok() {

--- a/src/token/realm.rs
+++ b/src/token/realm.rs
@@ -302,13 +302,14 @@ mod tests {
     
     #[test]
     fn test_file_path_creation(){
-       let basedir: Path = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let basedir: Path = Path::new(env!("CARGO_MANIFEST_DIR"));
 
-       let realm_claims_path: Path = basedir.join("testdata/realm-claims.cbor");
-       let num_key_path: Path =  basedir.join("testdata/realm-claims+spurious-numeric-key.cbor");
-       let text_key_path: Path = basedir.join("testdata/realm-claims+spurious-text-key.cbor");
-       let missing_claims_path: Path = basedir.join("testdata/realm-claims-missing-challange.cbor");
+        let realm_claims_path: Path = basedir.join("testdata/realm-claims.cbor");
+        let num_key_path: Path =  basedir.join("testdata/realm-claims+spurious-numeric-key.cbor");
+        let text_key_path: Path = basedir.join("testdata/realm-claims+spurious-text-key.cbor");
+        let missing_claims_path: Path = basedir.join("testdata/realm-claims-missing-challange.cbor");
     }
+    
     #[test]
     fn realm_ok() {
         let _r = Realm::decode(&TEST_REALM_CLAIMS_OK.to_vec()).expect("successful decode");


### PR DESCRIPTION
This branch changes the path of all the test-vectors with the help of `env` that are loaded from testdata.