### PR TITLE
chore(deps): update serde_with 3.4.0 to 3.14.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ hex = { version = "0.4", features = ["serde"] }
 thiserror = "1"
 hex-literal = "0.4.1"
 bitmask = "0.5.0"
-serde_with = { version = "3.4.0", features = ["hex"] }
+serde_with = { version = "3.14.0", features = ["hex"] }
 jsonwebtoken = "9.1.0"
 cose-rust = "0.1.7"
 ear = "0.3.0"

--- a/examples/token.rs
+++ b/examples/token.rs
@@ -14,10 +14,10 @@ fn realm_tokens_decode() {
     let files = vec!["testdata/realm-claims.cbor"];
 
     for f in files {
-        let buf = fs::read(f).unwrap_or_else(|_| panic!("loading file {}", f));
+        let buf = fs::read(f).unwrap_or_else(|_| panic!("loading file {f}"));
 
         let rc = Realm::decode(&buf).unwrap();
 
-        println!("{:#?}", rc);
+        println!("{rc:#?}");
     }
 }

--- a/src/store/errors.rs
+++ b/src/store/errors.rs
@@ -13,7 +13,7 @@ impl std::fmt::Debug for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Error::Syntax(e) | Error::Sema(e) => {
-                write!(f, "{}", e)
+                write!(f, "{e}")
             }
         }
     }

--- a/src/token/errors.rs
+++ b/src/token/errors.rs
@@ -65,7 +65,7 @@ impl std::fmt::Debug for Error {
             | Error::HashCalculateFail(e)
             | Error::NoCoseAlgInHeader(e)
             | Error::BadInternalState(e) => {
-                write!(f, "{}", e)
+                write!(f, "{e}")
             }
         }
     }

--- a/src/token/evidence.rs
+++ b/src/token/evidence.rs
@@ -76,10 +76,7 @@ impl CBORCollection {
 
         if let Value::Tag(t, m) = v {
             if t != CBOR_TAG {
-                return Err(Error::Syntax(format!(
-                    "expecting tag {}, got {}",
-                    CBOR_TAG, t
-                )));
+                return Err(Error::Syntax(format!("expecting tag {CBOR_TAG}, got {t}",)));
             }
 
             if let Value::Map(contents) = *m {
@@ -168,11 +165,11 @@ impl Evidence {
 
         t.platform
             .init_decoder(None)
-            .map_err(|e| Error::Syntax(format!("platform token: {:?}", e)))?;
+            .map_err(|e| Error::Syntax(format!("platform token: {e:?}")))?;
 
         t.realm
             .init_decoder(None)
-            .map_err(|e| Error::Syntax(format!("realm token: {:?}", e)))?;
+            .map_err(|e| Error::Syntax(format!("realm token: {e:?}")))?;
 
         t.platform_claims = Platform::decode(&t.platform.payload)?;
         t.realm_claims = Realm::decode(&t.realm.payload)?;

--- a/src/token/platform.rs
+++ b/src/token/platform.rs
@@ -341,8 +341,7 @@ impl Platform {
 
         if x_len != 32 {
             return Err(Error::Sema(format!(
-                "implementation-id: expecting 32 bytes, got {}",
-                x_len
+                "implementation-id: expecting 32 bytes, got {x_len}"
             )));
         }
 
@@ -363,8 +362,7 @@ impl Platform {
 
         if x_len != 33 {
             return Err(Error::Sema(format!(
-                "instance-id: expecting 33 bytes, got {}",
-                x_len
+                "instance-id: expecting 33 bytes, got {x_len}"
             )));
         }
 
@@ -477,8 +475,7 @@ impl Platform {
 
             if _xi.is_none() {
                 return Err(Error::TypeMismatch(format!(
-                    "sw-component[{}] MUST be map",
-                    i
+                    "sw-component[{i}] MUST be map"
                 )));
             }
 
@@ -505,7 +502,7 @@ mod tests {
 
         let _p = Platform::decode(&buf).unwrap();
 
-        println!("{:#?}", _p);
+        println!("{_p:#?}");
     }
 
     #[test]

--- a/src/token/realm.rs
+++ b/src/token/realm.rs
@@ -255,8 +255,7 @@ impl Realm {
         if self.profile.is_empty() {
             if x_len != 97 {
                 return Err(Error::Sema(format!(
-                    "public-key: expecting 97 bytes, got {}",
-                    x_len
+                    "public-key: expecting 97 bytes, got {x_len}"
                 )));
             }
             self.raw_rak[..].clone_from_slice(&x);
@@ -289,13 +288,12 @@ impl Realm {
 
         if x_len != 4 {
             return Err(Error::Sema(format!(
-                "extensible-measurements: expecting 4 slots, got {}",
-                x_len
+                "extensible-measurements: expecting 4 slots, got {x_len}"
             )));
         }
 
         for (i, xi) in x.iter().enumerate() {
-            self.rem[i] = to_measurement(xi, format!("extensible-measurement[{}]", i).as_str())?;
+            self.rem[i] = to_measurement(xi, format!("extensible-measurement[{i}]").as_str())?;
         }
 
         self.claims_set.set(Claims::Rem);
@@ -321,8 +319,7 @@ impl Realm {
 
         if x_len != 64 {
             return Err(Error::Sema(format!(
-                "personalization value: expecting 64 bytes, got {}",
-                x_len
+                "personalization value: expecting 64 bytes, got {x_len}"
             )));
         }
 


### PR DESCRIPTION
Hi all, this is a dependency update PR. The old version makes our downstream project some compilation error.
I hope it makes sense to update the denpendency version.

```
error: failed to select a version for `serde_with`.
    ... required by package `attester v0.1.0 (https://github.com/confidential-containers/guest-components.git?rev=591d0bb#591d0bb4)`
    ... which satisfies git dependency `attester` of package `kbs_protocol v0.1.0 (https://github.com/confidential-containers/guest-components.git?rev=591d0bb#591d0bb4)`
    ... which satisfies git dependency `kbs_protocol` of package `kbs-client v0.1.0 (/home/kbs/tools/kbs-client)`
    ... which satisfies path dependency `kbs-client` (locked to 0.1.0) of package `integration-tests v0.1.0 (/home/kbs/integration-tests)`
versions that meet the requirements `^3.14.0` are: 3.14.0

all possible versions conflict with previously selected packages.

  previously selected package `serde_with v3.13.0`
    ... which satisfies dependency `serde_with = "^3.4.0"` (locked to 3.13.0) of package `ccatoken v0.1.0 (https://github.com/veraison/rust-ccatoken?branch=trustee-cca#5a980d7a)`
    ... which satisfies git dependency `ccatoken` (locked to 0.1.0) of package `verifier v0.1.0 (/home/kbs/deps/verifier)`
    ... which satisfies path dependency `verifier` (locked to 0.1.0) of package `attestation-service v0.1.0 (/home/kbs/attestation-service)`
    ... which satisfies path dependency `attestation-service` (locked to 0.1.0) of package `integration-tests v0.1.0 (/home/kbs/integration-tests)`
```