### PR TITLE
feat: add documentation checks to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
       run: cargo fmt --all -- --check
     - name: Clippy checks
       run: cargo clippy --all-targets -- -D clippy::all -D clippy::cargo  -A clippy::multiple-crate-versions
+    - name: Documentation checks
+      run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/src/token/base64.rs
+++ b/src/token/base64.rs
@@ -16,9 +16,11 @@ pub fn decode_str(v: &str) -> Result<Vec<u8>, Error> {
 }
 
 /// a `Vec<u8>` encoded as base64 in human readable serialization
+#[allow(dead_code)]
 #[derive(Debug, PartialEq)]
 pub struct Bytes(Vec<u8>);
 
+#[allow(dead_code)]
 impl Bytes {
     pub fn new() -> Self {
         Bytes(Vec::new())
@@ -73,6 +75,7 @@ impl<'de> Deserialize<'de> for Bytes {
     }
 }
 
+#[allow(dead_code)]
 struct BytesVisitor;
 
 impl Visitor<'_> for BytesVisitor {


### PR DESCRIPTION
### Add Documentation checks to Cl pipeline
- Added 'cargo doc' with RUSTDOCFLAGS="-D warnings" to CI workflow
- Ensures documentation builds successfully and catches doc warnings
- Included --document-private-items flag for comprehensive doc coverage
- Fixed dead code warnings in base64.rs using #[allow(dead_code)]
- Resolves issue #23: documentation should be checked by the CI

The CI now validates:
1. Code formatting (cargo fmt)
2. Clippy lints
3. Documentation generation (NEW)
4. Build process
5. Test execution

Fixes #23 