### PR TITLE
Chore: Bump rust ear to candidate 0.6.0 and jsonwebtoken to 11.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,6 @@ bitflags = "2.11.0"
 serde_with = { version = "3.14.0", features = ["hex"] }
 jsonwebtoken = "11.0.0"
 cose-rust = "0.1.7"
-ear = "0.5.0"
+ear = "0.6.0"
 clap = { version = "4.4.10", features = ["derive"] }
 openssl = "0.10.72"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "1"
 hex-literal = "0.4.1"
 bitflags = "2.11.0"
 serde_with = { version = "3.14.0", features = ["hex"] }
-jsonwebtoken = "10.3.0"
+jsonwebtoken = "11.0.0"
 cose-rust = "0.1.7"
 ear = "0.5.0"
 clap = { version = "4.4.10", features = ["derive"] }

--- a/deny.toml
+++ b/deny.toml
@@ -106,6 +106,7 @@ allow = [
     "Unicode-3.0",
     "BSD-3-Clause",
     "MIT-0",
+    "BlueOak-1.0.0",
 ]
 
 # The confidence threshold for detecting a license from license text.


### PR DESCRIPTION
DO NOT MERGE this until rust-ear publishes new release. This is a dependency updation PR.